### PR TITLE
results: Add automerge feature to the repo

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,2 @@
+"automerge":
+  - "results/**/*"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,26 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+name: Publish results
+on:
+  workflow_run:
+    workflows: ["Check Results"]
+    types: [completed]
+
+jobs:
+  on-success:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Merge results
+        id: merge
+        uses: "pascalgn/automerge-action@v0.14.3"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_METHOD: "rebase"
+          
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - run: echo 'Results need manual verification. Publishing stopped.'   

--- a/.github/workflows/check_results.yml
+++ b/.github/workflows/check_results.yml
@@ -55,9 +55,9 @@ jobs:
             python3 scripts/results_verification.py -Z ${v} -P ./${file} -E 500 -F 500 -S 5
             if [ $? -eq 0 ]
             then
-              echo "Results file succesfully verified"
+              echo "Results file succesfully verified and will be automatically published"
             else
-              echo "Results file verification failed"
+              echo "Results file verification failed. Please ask @permac or @nashif for review if you want to get them merged"
               exit 1
             fi
           fi
@@ -69,4 +69,11 @@ jobs:
         # verify matching test spec
         # verify version
         # etc.
+        
+    - name: Put label
+      # Put `automerge` label if verification passed. Required for automerge action.
+      id: labeler
+      uses: actions/labeler@v3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
 


### PR DESCRIPTION
Add automerging for PRs with test results. After results are
successfully verified a label 'automerge' is added. The action
for automerging is triggered when verification ends. If the
verification was successful and the label exists, the results
are merged.

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>